### PR TITLE
Fix default n bug

### DIFF
--- a/lib/kujibiki/core_ext/array.rb
+++ b/lib/kujibiki/core_ext/array.rb
@@ -7,6 +7,7 @@ class Array
       raise ArgumentError, "weight size must be equal to array size(#{self.size})"
     end
 
+    n = 1 unless n
     n = self.size if n > self.size
 
     begin


### PR DESCRIPTION
Error occured with no n set.

```
NoMethodError: undefined method `>' for nil:NilClass
```

Because nil compared at this line.

``` ruby
n = self.size if n > self.size
```

This PR fix this problem by adding

``` ruby
n = 1 unless n
```
